### PR TITLE
Add support for pulling multiple metrics from New Relic - flat records

### DIFF
--- a/src/client/newrelic.ts
+++ b/src/client/newrelic.ts
@@ -19,7 +19,7 @@ export default class NewRelicClient {
             to,
             period: period.toString()
         });
-        names.forEach(name => params.append('names', name))
+        names.forEach(name => params.append('names[]', name))
         url.search = params.toString();
         return this.send(url);
     }

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -68,6 +68,10 @@
         "appId": {
           "description": "The numeric app ID associated with the environment you want data from",
           "type": "number"
+        },
+        "names": {
+          "description": "Metric names from New Relic API",
+          "type": "array"
         }
       },
       "required": ["type", "apiKey", "appId"],

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,4 +72,8 @@ export interface NewRelicSourceConfig {
    * The numeric app ID associated with the environment you want data from
    */
   appId: number;
+    /**
+     * The names of New Relic metrics being queried.
+     */
+  names?: Array<string>;
 }

--- a/src/source/newrelic.ts
+++ b/src/source/newrelic.ts
@@ -7,6 +7,7 @@ import Source from './source'
 export default class NewRelicSync implements Source {
     client: Client
     appId: number
+    names: Array<string>
     constructor(config: NewRelicSourceConfig) {
         if(!config.apiKey) {
             throw new Error('Missing apiKey')
@@ -16,6 +17,7 @@ export default class NewRelicSync implements Source {
         }
         this.client = new Client(config.apiKey);
         this.appId = config.appId;
+        this.names = config.names ? config.names : ['HttpDispatcher'];
     }
     getIndex() {
         return 'newrelic-YYYY-MM-DD';
@@ -25,18 +27,23 @@ export default class NewRelicSync implements Source {
     }
     async getData() {
         const appId = this.appId;
+        const names = this.names;
         const to = moment().startOf('hour');
         const from = moment().subtract(1, 'day');
-        const response = await this.client.getMetrics(appId, ['HttpDispatcher'], from.toISOString(), to.toISOString(), 3600);
-        const timeslices = mapTimeslices(response.metric_data.metrics[0].timeslices);
+        const response = await this.client.getMetrics(appId, names, from.toISOString(), to.toISOString(), 3600);
+        const metrics = response.metric_data.metrics;
 
-        return timeslices.map(function(timeslice) {
-           return Object.assign({}, timeslice, {
-             _id: `${appId}/${timeslice.from}/${timeslice.to}`,
-             '@timestamp': timeslice.from,
-             appId: appId
-           })
-        });
+        return [].concat(...metrics.map(function(metric) {
+            const timeslices = mapTimeslices(metric.timeslices);
+            return timeslices.map(function(timeslice) {
+                return Object.assign({}, timeslice, {
+                    _id: `${appId}/${metric.name}/${timeslice.from}/${timeslice.to}`,
+                    metricname: metric.name,
+                    '@timestamp': timeslice.from,
+                    appId: appId
+                })
+            });
+        }));
     }
 }
 

--- a/sync.example.yml
+++ b/sync.example.yml
@@ -11,6 +11,9 @@ sources:
   - type: newrelic
     apiKey: YOUR_NEW_RELIC_APIKEY
     appId: YOUR_NEW_RELIC_APP_ID
+    names:
+      - 'HttpDispatcher'
+      - 'Apdex'
   - type: acquia
     public_key: YOUR_ACQUIA_PUBLIC_API_KEY
     private_key: YOUR_ACQUIA_PRIVATE_API_KEY


### PR DESCRIPTION
This is a followup to #1 to flatten the additional metrics into a single record.   This does represent a breaking change, because the HTTPDispatcher properties have moved from the root of the record to being nested under a single HTTPDispatcher property.  The structure of a single record is now:
```
{
  "@timestamp": "123",
  "from": "123",
  "to": "123",
  "HttpDispatcher": {
    "average_call_time": 186,
    ...
  }
}
```
I think the tradeoff here is worth it though, since we don't have different _types_ of records floating around the same index.