### PR TITLE
Upgrade elasticsearch js library

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "main": "dist/index.js",
   "license": "MIT",
   "dependencies": {
+    "@elastic/elasticsearch": "^7.0.1",
     "ajv": "^6.5.2",
     "async-retry": "^1.2.3",
     "bluebird": "^3.5.1",
     "crypto-js": "^3.1.9-1",
-    "elasticsearch": "^15.1.1",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -91,12 +91,7 @@
   "properties": {
     "elasticsearch": {
       "description": "Elasticsearch connection details",
-      "type": "object",
-      "properties": {
-        "host": {
-          "type": "string"
-        }
-      }
+      "$ref": "#/definitions/ElasticSearchConnection"
     },
     "sources": {
       "description": "Source plugins",

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,6 @@ export interface Configuration {
    * Elasticsearch connection details
    */
   elasticsearch: {
-    host?: string;
     [k: string]: any;
   };
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,8 +72,8 @@ export interface NewRelicSourceConfig {
    * The numeric app ID associated with the environment you want data from
    */
   appId: number;
-    /**
-     * The names of New Relic metrics being queried.
-     */
-  names?: Array<string>;
+  /**
+   * Metric names from New Relic API
+   */
+  names?: any[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 
 import {Configuration} from "./config";
-import {Client} from 'elasticsearch'
+import {Client} from '@elastic/elasticsearch';
 import factory from './source/factory';
 import * as Promise from 'bluebird'
 import {omit} from 'lodash'

--- a/sync.example.yml
+++ b/sync.example.yml
@@ -1,7 +1,7 @@
 # Elasticsearch host information.
 #
 # Can be a simple string indicating hostname/port, or an object.
-# @see https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html
+# @see https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.x/client-configuration.html
 elasticsearch:
   host: elasticsearch:9200
 


### PR DESCRIPTION
This PR moves from the old `elasticsearch` JS library to the newer `@elastic/elasticsearch` one. 