### PR TITLE
Allow index to be set by source

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,10 @@ export interface Configuration {
 export interface AcquiaSourceConfig {
   type: "acquia";
   /**
+   * The name of the Elasticsearch index to write to (defaults to `acquia`)
+   */
+  index?: string;
+  /**
    * The public key associated with your Acquia account
    */
   public_key: string;
@@ -41,6 +45,10 @@ export interface AcquiaSourceConfig {
  */
 export interface CircleCiSourceConfig {
   type: "circleci";
+  /**
+   * The name of the index to write to (defaults to `circleci`)
+   */
+  index?: string;
   /**
    * The API key associated with your CircleCI account
    */
@@ -63,6 +71,10 @@ export interface CircleCiSourceConfig {
  */
 export interface NewRelicSourceConfig {
   type: "newrelic";
+  /**
+   * The name of the Elasticsearch index to write to (defaults to `newrelic`)
+   */
+  index?: string;
   /**
    * The API key associated with your New Relic account
    */

--- a/src/source/acquia.ts
+++ b/src/source/acquia.ts
@@ -9,13 +9,14 @@ import {groupBy, defaultsDeep, set} from 'lodash'
 export default class AcquiaSync implements Source {
     client: Client
     environmentId: string
-
+    index: string
     constructor(config: AcquiaSourceConfig) {
         this.client = new Client(config.public_key, config.private_key);
         this.environmentId = config.environmentId;
+        this.index = config.index ? config.index : 'acquia-YYYY-MM-DD'
     }
     getIndex() {
-        return 'acquia-YYYY-MM-DD';
+        return this.index
     }
     getType() {
         return 'acquia_stackmetric'

--- a/src/source/circleci.ts
+++ b/src/source/circleci.ts
@@ -9,6 +9,7 @@ export default class CircleCiSync implements Source {
     vcsType: string
     owner: string
     repo: string
+    index: string
 
     constructor(config: CircleCiSourceConfig) {
         if(!config.apiKey) {
@@ -27,9 +28,10 @@ export default class CircleCiSync implements Source {
         this.vcsType = config.vcsType
         this.owner = config.owner
         this.repo = config.repo
+        this.index = config.index ? config.index : 'circleci-YYYY-MM-DD'
     }
     getIndex() {
-        return 'circleci-YYYY-MM-DD';
+        return this.index
     }
     getType() {
         return 'circle_build'

--- a/src/source/newrelic.ts
+++ b/src/source/newrelic.ts
@@ -8,6 +8,7 @@ export default class NewRelicSync implements Source {
     client: Client
     appId: number
     names: Array<string>
+    index: string
     constructor(config: NewRelicSourceConfig) {
         if(!config.apiKey) {
             throw new Error('Missing apiKey')
@@ -18,9 +19,10 @@ export default class NewRelicSync implements Source {
         this.client = new Client(config.apiKey);
         this.appId = config.appId;
         this.names = config.names ? config.names : ['HttpDispatcher'];
+        this.index = config.index ? config.index : 'newrelic-YYYY-MM-DD'
     }
     getIndex() {
-        return 'newrelic-YYYY-MM-DD';
+        return this.index
     }
     getType() {
         return 'newrelic_metric'


### PR DESCRIPTION
This PR attempts to address an issue that's come up where writing daily indexes leads to way too many shards for a small ES cluster. After this PR, you have the option of using aliased indexes with ILM to manage where the writes go.  By default though, this PR changes nothing. 